### PR TITLE
Add all spiltting metrics

### DIFF
--- a/CoiPopAsess.py
+++ b/CoiPopAsess.py
@@ -2,6 +2,8 @@ import csv
 import matplotlib.pyplot as plt
 import geopandas as gp
 import math
+from locality_splitting import metrics
+import numpy as np
 
 ## TODO
 # To implement this COI analysis, you must import 5 files
@@ -100,23 +102,24 @@ plt.text(0.75, -0.95, 'The population of your COI \n is split into ' + str(len(d
          + 'The percent of your COI\'s pop \n in each district is labeled on the pie chart.')
 
 
-# Effective Splits and Uncertainty of Membership
-# Effective Splits = (1/SUM(Ni^2))-1
-# Uncertainty of Membership = -SUM(Nilog2Ni)
-# where Ni is the proportion of a community contained in a district
+# Calculate splitting metrics
+# see https://github.com/jacobwachspress/locality-splitting for details on calculations
 
-sumNi_ES = 0
-sumNI_UoM = 0
-for x in pops:
-    Ni = (int(x) / total_pop)
-    sumNi_ES += Ni ** 2
-    sumNI_UoM += (Ni * math.log2(Ni))
-effective_splits = (1 / sumNi_ES) - 1
-uncertainty_of_membership = -1 * sumNI_UoM
+# choose metrics here
+metrics_to_test = ['districts_intersecting', 'conditional_entropy', 'sqrt_entropy', 'effective_splits', 'split_pairs']
 
-print('Effective Splits = ' + str(effective_splits))
-print('Uncertainty of Membership = ' + str(uncertainty_of_membership))
+# calculate scores
+pops_arr = np.asarray(pops)
+split_metric_functions = {'districts_intersecting' : metrics.locality_intersections, 
+                         'conditional_entropy' : metrics.conditional_entropy,
+                         'sqrt_entropy' : metrics.sqrt_entropy,
+                         'effective_splits' : metrics.effective_splits, 
+                         'split_pairs' : metrics.split_pairs}
+d = {metric : split_metric_functions[metric](pops_arr) for metric in metrics_to_test}
 
+# print results
+print('Splitting metrics:')
+_ = [print(f'{key} = {d[key]}') for key in d]
 
 
 ## Map

--- a/README.md
+++ b/README.md
@@ -49,3 +49,9 @@ What to do once the files are downloaded:
 Open the COIPopAssess.py file in your Python IDE.  Through Finder (or Windows Explorer), drag and drop all files you downloaded into the folder that COIPopAssess.py is in.  Then, put the file path name of the five aforementioned files into their respective variables in the COIPopAssess program.  In COIPopAssess the variables are listed in the same order as 1-5 above. 
 Final note: downloading a shapefile will download a folder that includes a .cpg, .dbf, .prj and .shx file, in addition to the shapefile.  In order for the program to work, all these files must be kept with the shapefile in a single folder.  Import this entire folder to your working environment.  Only the shapefile needs to be directly referenced in the python program, however – the rest will be read automatically.
 
+Note: this script depends on this locality-splitting [package](https://github.com/jacobwachspress/locality-splitting), which you can install with 
+
+```
+pip install locality-splitting
+```
+


### PR DESCRIPTION
This incorporates the package [here](https://github.com/jacobwachspress/locality-splitting) into CoiPopAsess.py to allow calculations of COI splitting according to all metrics in the literature.